### PR TITLE
fix: code padding

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -247,6 +247,7 @@ code, tt {
 pre code {
   margin: 0;
   padding: 16px;
+  display: block;
   white-space: pre;
   border: none;
   overflow-x: auto;


### PR DESCRIPTION
A [recent commit](https://github.com/callstack/component-docs/commit/15713e9b50a2697215112ca3f7ae63eaff4f2358#diff-8da7f7cbf05a6c802b76d09c65c2f719R249) broke the code display a bit:

![screen shot 2018-05-10 at 15 16 48](https://user-images.githubusercontent.com/7827311/39871662-e07c35f6-5465-11e8-921f-884524d7f162.png)

After the fix it should look like:

![screen shot 2018-05-10 at 15 17 08](https://user-images.githubusercontent.com/7827311/39871677-ec2f05f4-5465-11e8-868e-5b88ef87c47d.png)