### PR TITLE
fix: pass link to static prop if its a component

### DIFF
--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -174,12 +174,15 @@ const MethodDoc = ({ name, description, type, params, returns }) => {
   );
 };
 
-const PropertyDoc = ({ name, description, type, value }: *) => {
+const PropertyDoc = ({ name, description, type, value, link }: *) => {
   const typeName = type ? getTypeName(type) : null;
 
   return (
     <PropInfo>
-      <PropLabel name={name} href={`#${name}`}>
+      <PropLabel
+        name={name}
+        href={`${typeName === 'static' && link ? `${link}` : `#${name}`}`}
+      >
         <code>{name}</code>
       </PropLabel>
       {typeName && typeName !== 'unknown' ? (

--- a/src/types.js
+++ b/src/types.js
@@ -72,6 +72,7 @@ export type Docs = {
     description?: string,
     type?: TypeAnnotation,
     value?: string,
+    link?: ?string,
   |}>,
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

In `react-native-paper` documentation link to static props which is an component accessible with dot notation the link try to redirect with the `#` to current page section.

This PR brings logic that changes the links for `Static Prooperties` and redirect to separate `html` page with below pattern:
```jsx
${componentName}-{staticPropertyName}.html
```
It affects only `PropDocs` component in `Documentation.js` file. For `MethodDoc` it do not change the links

Link to `react-paper-issue`: 

If it gets merge open PR in paper to bump the component docs version.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

1. Gererate `react-native-paper` docs after linking those changes locally
2. See how the links behave

### Screenshots

**BEFORE:**
<image src="https://user-images.githubusercontent.com/21242757/79828528-2875bf00-83a1-11ea-91fc-bed741557d57.gif" />

**AFTER:**
<image src="https://user-images.githubusercontent.com/21242757/79828557-37f50800-83a1-11ea-837f-8fbbb60de3d4.gif" />




