### PR TITLE
feat: add optional snack player to component examples

### DIFF
--- a/example/__fixtures__/component/Button.js
+++ b/example/__fixtures__/component/Button.js
@@ -6,20 +6,8 @@ import PropTypes from 'prop-types';
 /**
  * Buttons communicate the action that will occur when the user touches them
  *
- * <div class="screenshots">
- *   <img src="screenshots/button-raised.png" />
- *   <img src="screenshots/button-primary.png" />
- *   <img src="screenshots/button-custom.png" />
- * </div>
+ * @SnackPlayer Button.SimpleUsage.js
  *
- * ## Usage
- * ```js
- * const MyComponent = () => (
- *   <Button raised onPress={() => console.log('Pressed')}>
- *     Press me
- *   </Button>
- * );
- * ```
  * @extends TouchableWithoutFeedback props https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#props
  */
 export default class Button extends Component {

--- a/example/__fixtures__/component/Dialog.tsx
+++ b/example/__fixtures__/component/Dialog.tsx
@@ -64,6 +64,9 @@ type Props = {
  *   }
  * }
  * ```
+ * 
+ * @SnackPlayer Dialog.SimpleUsage.js
+ * 
  */
 export default class Dialog extends React.Component<Props> {
   /**

--- a/example/__fixtures__/examples/Button.SimpleUsage.js
+++ b/example/__fixtures__/examples/Button.SimpleUsage.js
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button, Provider as PaperProvider } from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+
+const ButtonSimpleUsage = () => (
+  <PaperProvider>
+    <View style={styles.container}>
+      <Button onPress={() => {}}>Default</Button>
+      <Button
+        onPress={() => {}}
+        icon={props => <Icon name="add-a-photo" {...props} />}
+      >
+        Icon
+      </Button>
+      <Button onPress={() => {}} loading>
+        Loading
+      </Button>
+    </View>
+  </PaperProvider>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    marginHorizontal: 48,
+  },
+});
+
+export default ButtonSimpleUsage;

--- a/example/__fixtures__/examples/Dialog.SimpleUsage.js
+++ b/example/__fixtures__/examples/Dialog.SimpleUsage.js
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+import {
+  Button,
+  Paragraph,
+  Dialog,
+  Portal,
+  Provider as PaperProvider,
+} from 'react-native-paper';
+
+const DialogSimpleUsage = () => {
+  const [showDialog, setShowDialog] = React.useState(true);
+
+  return (
+    <PaperProvider>
+      <View style={styles.container}>
+        <Button onPress={() => setShowDialog(true)}>Show Dialog</Button>
+        <Portal>
+          <Dialog visible={showDialog} onDismiss={() => setShowDialog(false)}>
+            <Dialog.Title>Alert</Dialog.Title>
+            <Dialog.Content>
+              <Paragraph>This is simple dialog</Paragraph>
+            </Dialog.Content>
+            <Dialog.Actions>
+              <Button onPress={() => setShowDialog(false)}>Done</Button>
+            </Dialog.Actions>
+          </Dialog>
+        </Portal>
+      </View>
+    </PaperProvider>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    marginHorizontal: 48,
+  },
+});
+
+export default DialogSimpleUsage;

--- a/src/parsers/component.js
+++ b/src/parsers/component.js
@@ -59,6 +59,7 @@ export default function component(
   { root }: { root: string }
 ): Metadata {
   let content = '';
+  let snackPlayers = []
 
   const lines = fs.readFileSync(filepath, 'utf-8').split('\n');
 
@@ -66,6 +67,23 @@ export default function component(
 
   for (const line of lines) {
     if (line === '// @component-docs ignore-next-line') {
+      skip = true;
+      continue;
+    }
+
+    if (line.includes('@SnackPlayer')) {
+      const parts = line.split(' ').slice(1);
+      const snackPlayerName = parts.pop();
+      const snackPlayerPath = path.join(filepath, '..', '..', 'examples', snackPlayerName)
+      if(fs.existsSync(snackPlayerPath)){
+        snackPlayers.push({
+          name: snackPlayerName,
+          code:  fs.readFileSync(
+            snackPlayerPath,
+            'utf-8'
+          ),
+        });
+      }
       skip = true;
       continue;
     }
@@ -93,6 +111,7 @@ export default function component(
     filepath: path.relative(root, filepath),
     title: name,
     description: info.description,
+    snackPlayers: snackPlayers,
     link: dashify(name),
     data: info,
     type: 'component',

--- a/src/parsers/component.js
+++ b/src/parsers/component.js
@@ -59,7 +59,7 @@ export default function component(
   { root }: { root: string }
 ): Metadata {
   let content = '';
-  let snackPlayers = []
+  let snackPlayers = [];
 
   const lines = fs.readFileSync(filepath, 'utf-8').split('\n');
 
@@ -74,14 +74,17 @@ export default function component(
     if (line.includes('@SnackPlayer')) {
       const parts = line.split(' ').slice(1);
       const snackPlayerName = parts.pop();
-      const snackPlayerPath = path.join(filepath, '..', '..', 'examples', snackPlayerName)
-      if(fs.existsSync(snackPlayerPath)){
+      const snackPlayerPath = path.join(
+        filepath,
+        '..',
+        '..',
+        'examples',
+        snackPlayerName
+      );
+      if (fs.existsSync(snackPlayerPath)) {
         snackPlayers.push({
           name: snackPlayerName,
-          code:  fs.readFileSync(
-            snackPlayerPath,
-            'utf-8'
-          ),
+          code: fs.readFileSync(snackPlayerPath, 'utf-8'),
         });
       }
       skip = true;

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -46,6 +46,7 @@ const buildRoutes = (
                 info={info}
                 github={github}
                 filepath={item.filepath}
+                snackPlayers={item.snackPlayers}
               />
             </Layout>
           );

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -5,6 +5,7 @@ import { styled } from 'linaria/react';
 import Content from './Content';
 import Markdown from './Markdown';
 import EditButton from './EditButton';
+import SnackPlayer from './SnackPlayer';
 import type { TypeAnnotation, Docs } from '../types';
 
 type Props = {
@@ -204,7 +205,7 @@ const PropertyDoc = ({ name, description, type, value }: *) => {
   );
 };
 
-export default function Documentation({ name, info, github, filepath }: Props) {
+export default function Documentation({ name, info, github, filepath, snackPlayers }: Props) {
   const restProps = [];
   const description = info.description
     .split('\n')
@@ -270,6 +271,15 @@ export default function Documentation({ name, info, github, filepath }: Props) {
       <EditButton github={github} filepath={filepath} />
       <Title>{name}</Title>
       <MarkdownContent source={description} options={{ linkify: true }} />
+
+      {snackPlayers.length ? (
+        <React.Fragment>
+          {snackPlayers.map(snackPlayer => (
+            <SnackPlayer snackPlayer={snackPlayer} key={snackPlayer.name} />
+          ))}
+        </React.Fragment>
+      ) : null}
+
       {keys.length || restProps.length ? (
         <React.Fragment>
           <h2>Props</h2>

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -205,7 +205,13 @@ const PropertyDoc = ({ name, description, type, value }: *) => {
   );
 };
 
-export default function Documentation({ name, info, github, filepath, snackPlayers }: Props) {
+export default function Documentation({
+  name,
+  info,
+  github,
+  filepath,
+  snackPlayers,
+}: Props) {
   const restProps = [];
   const description = info.description
     .split('\n')

--- a/src/templates/SnackPlayer.js
+++ b/src/templates/SnackPlayer.js
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+/**
+ * Include SnackPlayer by adding @SnackPlayer followed by the example component filename.
+ *
+ * Example:
+ * @SnackPlayer Button.SimpleUsage.js
+ *
+ */
+
+const SnackPlayer = ({ snackPlayer }) => {
+  React.useEffect(() => window.ExpoSnack && window.ExpoSnack.initialize(), []);
+
+  const code = encodeURIComponent(snackPlayer.code);
+
+  // https://github.com/expo/snack-sdk/blob/master/Snack_for_module_authors.md#parameters
+  return (
+    <div className="snack-player" style={{ marginTop: 15, marginBottom: 15 }}>
+      <div
+        data-snack-code={code}
+        data-snack-name={snackPlayer.name}
+        data-snack-platform="web"
+        data-snack-preview="true"
+        data-snack-dependencies={[
+          'react-native-paper',
+          'react-native-vector-icons/MaterialIcons',
+        ]}
+        style={{
+          overflow: 'hidden',
+          background: '#fafafa',
+          border: '1px solid rgba(0,0,0,.08)',
+          borderRadius: '4px',
+          height: '505px',
+          width: '100%',
+        }}
+      />
+    </div>
+  );
+};
+
+export default SnackPlayer;

--- a/src/utils/buildHTML.js
+++ b/src/utils/buildHTML.js
@@ -49,6 +49,8 @@ export default function buildHTML({
 
   body += '<script src="app.bundle.js"></script>';
 
+  body += '<script async src="https://snack.expo.io/embed.js"></script>';
+
   scripts.forEach(s => {
     body += `<script src="${s}"></script>`;
   });


### PR DESCRIPTION
### Summary

Snack players in docs showing components on different devices.

### Test plan

yarn example

### Screenshots

![Screenshot from 2020-05-05 10-42-10](https://user-images.githubusercontent.com/15336791/81026430-702a3980-8ebd-11ea-9fe9-b94f41c12810.png)

![Screenshot from 2020-05-05 10-42-48](https://user-images.githubusercontent.com/15336791/81026438-74eeed80-8ebd-11ea-86cf-c97af204eb15.png)

### Docs

[Inline Examples](https://reactnative.dev/blog/2016/07/06/toward-better-documentation#inline-examples)

[use snack.io instead of react-native-web-player](https://github.com/facebook/react-native-website/issues/1131)