### PR TITLE
feat: export Header and ToggleTheme component to allow use in js

### DIFF
--- a/components.js
+++ b/components.js
@@ -1,3 +1,5 @@
 /* @flow */
 
 exports.Link = require('./dist/templates/Link').default;
+exports.ThemeToggle = require('./dist/templates/ThemeToggle').default;
+exports.Header = require('./dist/templates/Header').default;


### PR DESCRIPTION
fixes #38 

Add export statement for `Header` and `ThemeToggle` components to allow direct use in react-native-paper `.js` docs sections (Home and Showcase)

