### PR TITLE
feat: enable highlighting js tagged template literals and modern js syntax

### DIFF
--- a/example/__fixtures__/markdown/2.Markdown.md
+++ b/example/__fixtures__/markdown/2.Markdown.md
@@ -251,6 +251,27 @@ Here is an example of AppleScript:
         beep
     end tell
 
+Here is another example with syntax highlighting for React JSX and Linaria:
+
+```js
+import { styled } from 'linaria/react';
+
+// Create a styled component
+const Title = styled.h1`
+  font-size: 24px;
+  font-weight: bold;
+
+  &.title {
+    text-transform: capitalize;
+  }
+`;
+
+function Heading() {
+  // Use the styled component
+  return <Title>This is a title</Title>;
+}
+```
+
 A code block continues until it reaches a line that is not indented
 
 (or the end of the article).

--- a/src/utils/highlight.js
+++ b/src/utils/highlight.js
@@ -8,6 +8,8 @@ const aliases = {
 
 refractor.register(require('refractor/lang/clike'));
 refractor.register(require('refractor/lang/javascript'));
+refractor.register(require('refractor/lang/js-extras'));
+refractor.register(require('refractor/lang/js-templates'));
 refractor.register(require('refractor/lang/typescript'));
 refractor.register(require('refractor/lang/markup'));
 refractor.register(require('refractor/lang/jsx'));


### PR DESCRIPTION
### Summary

Enable highlighting of CSS-in-JS and the like in tagged template literals (via `js-templates` language extension) as well as better js syntax tokenization (via `js-extras`).

### Test plan

I've added a sample codeblock to `example/__fixtures__/markdown/2.Markdown.md` to preview. It should highlight the CSS inside tagged template for styled component:

<img width="802" alt="image" src="https://user-images.githubusercontent.com/234226/97783559-38315400-1bcb-11eb-90bd-cc027be4d36e.png">

